### PR TITLE
add:SHAP値を使って説明変数貢献度を可視化する

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scikit-learn==1.3.2
 jpholiday==0.1.8
 prophet==1.1.5
 plotly==5.18.0
+shap==0.44.0

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -9,6 +9,7 @@ from backend.module.prophet import (
     extract_df_with_prophet_data,
 )
 from backend.module.read_dataset import read_dataset, get_holidays_jp
+from backend.module.shap import create_and_plot_shap_value
 from backend.random_forest import regressor
 
 
@@ -34,3 +35,5 @@ rf = regressor.Regressor()
 model = rf.make_random_forest_model(20, 9, 4, 8, 0.16)
 rf_model, pred = rf.fit_predict_rf_model(model, x_train, y_train, x_test)
 r2_score = rf.calc_r2_score(y_test, pred)
+
+shap_values = create_and_plot_shap_value(rf_model, x_train)

--- a/src/backend/module/shap.py
+++ b/src/backend/module/shap.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import numpy as np
+
+import shap
+from sklearn.ensemble import RandomForestRegressor
+
+
+def create_and_plot_shap_value(
+    rf_model: RandomForestRegressor, x_train: pd.DataFrame
+) -> np.ndarray:
+    """
+    モデルのSHAP値を算出する
+    args:
+      rf_model: 訓練済みのRandomForestモデル
+      x_train: 訓練用の説明変数テーブル
+    """
+    explainer = shap.TreeExplainer(rf_model)
+    shap_values = explainer.shap_values(X=x_train)
+    shap.summary_plot(shap_values, x_train)
+    return shap_values


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- 検証の中で、説明変数の寄与度が可視化される状態を目指したい

# チケット・参考リンク
- なし

# 変更内容
- モデルと説明変数の値をargsに指定することで、SHAP値が算出されるメソッドを作成

# 動作確認（確認方法とプロセスを明確に記載する）
- ローカルでの確認
  - `cd path/to/src && python backend/main.py`

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
