### PR TITLE
Feature/add frontend 20240112

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.31.0
 prophet==1.1.5
 plotly==5.18.0
 shap==0.44.0
+streamlit==1.29.0

--- a/src/frontend/pages/index.py
+++ b/src/frontend/pages/index.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+import streamlit as st
+from streamlit.runtime.uploaded_file_manager import UploadedFile
+
+sys.path.append(str(Path().absolute()))
+from src.backend.module.read_dataset import read_dataset
+
+
+def initialize_state():
+    st.session_state["show_prophet"] = 0
+    st.session_state["show_table"] = 0
+
+
+def show_table(input_file: UploadedFile) -> None:
+    st.markdown("### 📈インプットデータの表示")
+    if st.session_state["show_table"] > 0:
+        st.dataframe(input_file)
+    if st.sidebar.button(label="非表示", key="テーブル非表示"):
+        st.session_state["show_status"] = 0
+
+
+def render():
+    initialize_state()
+    st.title("工場入荷予測モデル")
+    input_file = st.sidebar.file_uploader(label="インプットファイルをアップロードしてください。", type=["csv"])
+    if input_file:
+        file = read_dataset(input_file, "day")
+        if st.sidebar.button(label="インプットデータの表示", key="インプットデータの表示"):
+            st.session_state["show_table"] = 1
+            show_table(file)
+
+
+render()


### PR DESCRIPTION
### GitHub運用方針：https://www.notion.so/Git-1ce7523b93ca4d87a2df669e705a57d7

# 目的・概要
- クリーニング工場の入荷予測モデルを検証したい
  - 簡単にフロントエンドを実装する

# チケット・参考リンク
- なし

# 変更内容
- streamlitライブラリの追加
  - 簡単なフロントエンドを実装

# 動作確認（確認方法とプロセスを明確に記載する）
- ローカルでの確認
  - `cd path/to/root && streamlit run src/frontend/pages/index.py`
  - ファイルのアップロードと、テーブル表示/非表示を切り替え可能であることを確認済

# レビュアー
- @yukihirano0425

# チェックポイント
- [x] 動作確認は実施したか
- [ ] プルリクにラベル付けは実施しているか
- [x] プルリクにAssigneesは割り当てられているか
